### PR TITLE
[BL-16637] Adds identifierTypeCode to the OBR segment.

### DIFF
--- a/lib/core_ext/segments/obr.rb
+++ b/lib/core_ext/segments/obr.rb
@@ -84,7 +84,8 @@ module Extensions
                                 "idTypeCode" => orderingProvider[12],
                                 "isTypeCode" => orderingProvider[13],
                                 "assigningFacility" => orderingProvider[14],
-                                "providerType" => "OP"
+                                "providerType" => "OP",
+                                "identifierTypeCode" => orderingProvider[12]
                               },
                           "orderCallBackNumber" => self.order_callback_phone_number,
                           "placerField1" => self.placer_field_1,

--- a/ruby-hl7-extensions.gemspec
+++ b/ruby-hl7-extensions.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |s|
   s.name = "ruby-hl7-extensions"
-  s.version = "0.4.5"
+  s.version = "0.4.6"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib"]


### PR DESCRIPTION
Allows us to use the NPI identifier for OBR segments.